### PR TITLE
refactor: axiosをWeb標準のfetch APIに置き換え

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -80,7 +80,6 @@
     {{- .Scratch.Set "Author" .Site.Params.meta.author -}}
   {{ end }}
   <link rel="alternate" type="application/atom+xml" title="Atom" href="/index.xml"/>
-  <script src="https://cdn.jsdelivr.net/npm/axios@1.14.0/dist/axios.min.js"></script>
   <script src="{{ "js/vue.min.js" | relURL }}"></script>
   <script src="{{ "js/good-counter.js" | relURL }}" defer></script>
   {{ partial "google_analytics.html" . }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -80,7 +80,7 @@
     {{- .Scratch.Set "Author" .Site.Params.meta.author -}}
   {{ end }}
   <link rel="alternate" type="application/atom+xml" title="Atom" href="/index.xml"/>
-  <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/axios@1.14.0/dist/axios.min.js"></script>
   <script src="{{ "js/vue.min.js" | relURL }}"></script>
   <script src="{{ "js/good-counter.js" | relURL }}" defer></script>
   {{ partial "google_analytics.html" . }}

--- a/static/js/good-counter.js
+++ b/static/js/good-counter.js
@@ -27,15 +27,15 @@ Vue.component('good-counter', {
       this.display_button_name = '<i class="fas fa-heart"></i>';
     }
 
-    axios
-      .get(reqUrl, {
-        headers: {
-          "Content-Type": "application/json",
-        },
-        data: {}
-      })
-      .then(response => {
-        this.good_count = response.data.count;
+    fetch(reqUrl, {
+      method: 'GET',
+      headers: {
+        "Content-Type": "application/json",
+      },
+    })
+      .then(response => response.json())
+      .then(data => {
+        this.good_count = data.count;
       })
   },
   methods: {
@@ -56,10 +56,12 @@ Vue.component('good-counter', {
       let reqUrl = 'https://hobigon.yyh-gl.dev/api/v1/blogs/' + title+ '/like';
 
       if(event) {
-        axios
-          .post(reqUrl)
-          .then(response => {
-            this.good_count = response.data.count;
+        fetch(reqUrl, {
+          method: 'POST',
+        })
+          .then(response => response.json())
+          .then(data => {
+            this.good_count = data.count;
 
             // ローカルストレージにいいねされたことを保存
             localStorage.setItem(`${title}`, 'like');


### PR DESCRIPTION
## 概要

axiosのサプライチェーン攻撃（2026年3月）への対応として、CDN経由で読み込んでいたaxiosを削除し、ブラウザ標準の **fetch API** に移行します。

## 背景

- axiosのメンテナーアカウントが乗っ取られ、悪意あるバージョン `1.14.1` / `0.30.4` がnpmに公開された
- 悪意あるバージョンには `plain-crypto-js` という不正な依存関係が追加されており、インストール時にクロスプラットフォーム対応のRATをダウンロード・実行する
- 参考: https://blog.flatt.tech/entry/axios_compromise

## 本リポジトリへの影響

| 観点 | 状況 |
|------|------|
| npm依存関係 | axiosはpackage.jsonに含まれていない → postinstallスクリプトの影響なし |
| CDN読み込み | バージョン未固定のためlatestを取得 → **悪意あるバージョンが配信される可能性あり** |

`layouts/partials/head.html` でaxiosをjsDelivrのCDN経由でバージョン未固定で読み込んでいたため、jsDelivrが `1.14.1` を配信した場合にブログ訪問者のブラウザで悪意あるコードが実行されるリスクがあった。

## 変更内容

バージョン固定での一時対応ではなく、axios自体を削除してブラウザ標準のfetch APIに置き換えることで、サプライチェーン攻撃のリスクを根本的に解消する。

### `layouts/partials/head.html`

```diff
- <script src="https://cdn.jsdelivr.net/npm/axios@1.14.0/dist/axios.min.js"></script>
  <script src="{{ "js/vue.min.js" | relURL }}"></script>
```

### `static/js/good-counter.js`

**GET リクエスト（いいね数取得）:**

```diff
- axios
-   .get(reqUrl, { headers: { "Content-Type": "application/json" }, data: {} })
-   .then(response => { this.good_count = response.data.count; })
+ fetch(reqUrl, { method: 'GET', headers: { "Content-Type": "application/json" } })
+   .then(response => response.json())
+   .then(data => { this.good_count = data.count; })
```

**POST リクエスト（いいね追加）:**

```diff
- axios
-   .post(reqUrl)
-   .then(response => { this.good_count = response.data.count; ... })
+ fetch(reqUrl, { method: 'POST' })
+   .then(response => response.json())
+   .then(data => { this.good_count = data.count; ... })
```

## 備考

- fetch APIは2017年以降の全モダンブラウザで対応済み、ポリフィル不要
- `content/blog/*.md` 内のaxios言及はブログ記事本文のため変更対象外

https://claude.ai/code/session_013PcpL2PXLe7EsswDj43dNP